### PR TITLE
add missing include for printf() in scm-set.cpp

### DIFF
--- a/scm-set.cpp
+++ b/scm-set.cpp
@@ -12,7 +12,7 @@
 
 #include <GL/glew.h>
 #include <cassert>
-
+#include <stdio.h>
 #include "scm-set.hpp"
 #include "scm-index.hpp"
 


### PR DESCRIPTION
simplest fix but could also be done with cout if that's desired.
